### PR TITLE
Move Write logic outside of generator

### DIFF
--- a/modules/cli-wrapper/src/main/java/net/gspatace/json/schema/podo/generator/cli/commands/subcommands/GenerateCommand.java
+++ b/modules/cli-wrapper/src/main/java/net/gspatace/json/schema/podo/generator/cli/commands/subcommands/GenerateCommand.java
@@ -3,6 +3,8 @@ package net.gspatace.json.schema.podo.generator.cli.commands.subcommands;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.gspatace.json.schema.podo.generator.core.base.AbstractGenerator;
 import net.gspatace.json.schema.podo.generator.core.base.BaseOptions;
+import net.gspatace.json.schema.podo.generator.core.base.ProcessedSourceFile;
+import net.gspatace.json.schema.podo.generator.core.base.SourceFilesDiskWriter;
 import net.gspatace.json.schema.podo.generator.core.services.GeneratorsService;
 import picocli.CommandLine;
 
@@ -29,7 +31,8 @@ public class GenerateCommand implements Runnable {
         final Optional<AbstractGenerator> generatorInstance = GeneratorsService.getInstance().getGeneratorInstance(getOptions());
         generatorInstance.ifPresent(instance -> {
             try {
-                instance.generate();
+                List<ProcessedSourceFile> files = instance.generate();
+                new SourceFilesDiskWriter(files, outputDirectory).writeToDisk();
             } catch (JsonProcessingException e) {
                 e.printStackTrace();
             }
@@ -41,7 +44,6 @@ public class GenerateCommand implements Runnable {
         return builder
                 .generatorName(generatorName)
                 .inputSpec(inputFile)
-                .outputDirectory(outputDirectory)
                 .generatorSpecificProperties(getUnifiedGeneratorSpecificProperties())
                 .build();
     }

--- a/modules/core/src/main/java/net/gspatace/json/schema/podo/generator/core/base/BaseOptions.java
+++ b/modules/core/src/main/java/net/gspatace/json/schema/podo/generator/core/base/BaseOptions.java
@@ -19,6 +19,5 @@ import lombok.Data;
 public class BaseOptions {
     private final String generatorName;
     private final String inputSpec;
-    private final String outputDirectory;
     private final String[] generatorSpecificProperties;
 }

--- a/modules/core/src/main/java/net/gspatace/json/schema/podo/generator/core/base/ProcessedSourceFile.java
+++ b/modules/core/src/main/java/net/gspatace/json/schema/podo/generator/core/base/ProcessedSourceFile.java
@@ -1,0 +1,25 @@
+package net.gspatace.json.schema.podo.generator.core.base;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * @author George Spătăcean
+ */
+
+@AllArgsConstructor
+@Getter
+public class ProcessedSourceFile {
+    /**
+     * File path including directories from the
+     * initial logic directory.
+     * e.g. "src/main/java/some/package/File.java" or
+     * "Model.hpp"
+     */
+    private final String filePath;
+
+    /**
+     * Final contents of a source
+     */
+    private final String fileContent;
+}

--- a/modules/core/src/test/java/net/gspatace/json/schema/podo/generator/core/services/GeneratorServicesTests.java
+++ b/modules/core/src/test/java/net/gspatace/json/schema/podo/generator/core/services/GeneratorServicesTests.java
@@ -37,7 +37,6 @@ public class GeneratorServicesTests {
         final String[] testCustomProps = {"-customOptionOne", "custOptOneValue", "-customOptionTwo", "custOptTwoValue"};
         final BaseOptions baseOptions = BaseOptions.builder()
                 .generatorName(testGeneratorName)
-                .outputDirectory("testTempDir")
                 .generatorSpecificProperties(testCustomProps)
                 .build();
         final AbstractGenerator testGenerator = generatorService.getGeneratorInstance(baseOptions).get();


### PR DESCRIPTION
Externalize writer logic from the generator itself
This decoupling offers flexibility in terms of how to handle processed source files