### PR TITLE
Add REST API on top of core generation logic

### DIFF
--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -40,11 +40,6 @@
       <version>1.15</version>
     </dependency>
     <dependency>
-      <groupId>org.reflections</groupId>
-      <artifactId>reflections</artifactId>
-      <version>0.9.12</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
       <version>2.17.1</version>
@@ -73,6 +68,11 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
       <version>1.21</version>
+    </dependency>
+    <dependency>
+      <groupId>io.github.classgraph</groupId>
+      <artifactId>classgraph</artifactId>
+      <version>4.8.146</version>
     </dependency>
   </dependencies>
 

--- a/modules/rest-api/pom.xml
+++ b/modules/rest-api/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>net.gspatace</groupId>
+    <artifactId>json-schema-podo-generator</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <name>podo-generator-rest-api</name>
+  <artifactId>podo-generator-rest-api</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>net.gspatace</groupId>
+      <artifactId>podo-generator-core</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-slf4j-impl</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+      <version>2.6.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>2.7.0</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>2.2.6.RELEASE</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/modules/rest-api/src/main/java/net/gspatace/json/schema/podo/generator/rest/PodoGeneratorRestApi.java
+++ b/modules/rest-api/src/main/java/net/gspatace/json/schema/podo/generator/rest/PodoGeneratorRestApi.java
@@ -1,0 +1,19 @@
+package net.gspatace.json.schema.podo.generator.rest;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Spring REST API over
+ * json-schema-podo-generator logic
+ *
+ * @author George Spătăcean
+ */
+@SpringBootApplication
+public class PodoGeneratorRestApi
+{
+    public static void main( String[] args )
+    {
+        SpringApplication.run(PodoGeneratorRestApi.class, args);
+    }
+}

--- a/modules/rest-api/src/main/java/net/gspatace/json/schema/podo/generator/rest/controllers/GeneratorController.java
+++ b/modules/rest-api/src/main/java/net/gspatace/json/schema/podo/generator/rest/controllers/GeneratorController.java
@@ -1,0 +1,98 @@
+package net.gspatace.json.schema.podo.generator.rest.controllers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import net.gspatace.json.schema.podo.generator.core.base.AbstractGenerator;
+import net.gspatace.json.schema.podo.generator.core.base.GeneratorInput;
+import net.gspatace.json.schema.podo.generator.core.base.ProcessedSourceFile;
+import net.gspatace.json.schema.podo.generator.core.base.SourceFilesArchiveBuilder;
+import net.gspatace.json.schema.podo.generator.core.services.GeneratorDescription;
+import net.gspatace.json.schema.podo.generator.core.services.GeneratorNotFoundException;
+import net.gspatace.json.schema.podo.generator.core.services.GeneratorsService;
+import net.gspatace.json.schema.podo.generator.core.services.OptionDescription;
+import net.gspatace.json.schema.podo.generator.rest.models.CustomOption;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Main Wrapper over json-schema-podo-generator
+ * core logic.
+ * Exposes APIs for
+ * <ul>
+ *     <li>Generators listing</li>
+ *     <li>Specific Generator options</li>
+ *     <li>Generate archived code based on input</li>
+ * </ul>
+ *
+ * @author George Spătăcean
+ */
+@RestController
+@RequestMapping("/generators")
+@Slf4j
+public class GeneratorController {
+
+    @GetMapping("")
+    public List<GeneratorDescription> listGenerator() {
+        return GeneratorsService.getInstance().getAvailableGenerators();
+    }
+
+    @GetMapping("/{generatorName}")
+    public Set<OptionDescription> listGeneratorProperties(@PathVariable final String generatorName) {
+        return GeneratorsService.getInstance().getSpecificGeneratorOptions(generatorName);
+    }
+
+    @PostMapping(value = "/{generatorName}",
+            consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE},
+            produces = {MediaType.APPLICATION_OCTET_STREAM_VALUE})
+    public ResponseEntity<Resource> serveGeneratedCodeArchive(@PathVariable final String generatorName,
+                                                              @RequestParam final String options,
+                                                              @RequestParam final MultipartFile schema,
+                                                              @RequestParam(defaultValue = "json-schema-generated-podos") final String archiveName)
+            throws IOException, GeneratorNotFoundException {
+
+        final String fileContents = new String(schema.getBytes());
+        final GeneratorInput generatorInput = GeneratorInput.builder()
+                .generatorName(generatorName)
+                .inputSpec(fileContents)
+                .generatorSpecificProperties(formatGeneratorOptionsInput(options))
+                .build();
+        final AbstractGenerator generatorInstance = GeneratorsService.getInstance().getGeneratorInstance(generatorInput);
+        final List<ProcessedSourceFile> processedSources = generatorInstance.generate();
+        final byte[] archive = new SourceFilesArchiveBuilder(processedSources).buildArchive();
+        final InputStreamResource resource = new InputStreamResource(new ByteArrayInputStream(archive));
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + archiveName + ".zip\"")
+                .body(resource);
+    }
+
+    private String[] formatGeneratorOptionsInput(final String options) {
+        final ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            final List<CustomOption> customOptions = objectMapper.readValue(options, new TypeReference<List<CustomOption>>() {
+            });
+            final List<String> propList = new ArrayList<>();
+            customOptions.forEach(option -> {
+                propList.add(option.getName());
+                propList.add(option.getValue());
+            });
+            return propList.toArray(new String[0]);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to map specific options, these will be defaulted:", e);
+        }
+        return new String[0];
+    }
+}

--- a/modules/rest-api/src/main/java/net/gspatace/json/schema/podo/generator/rest/models/CustomOption.java
+++ b/modules/rest-api/src/main/java/net/gspatace/json/schema/podo/generator/rest/models/CustomOption.java
@@ -1,0 +1,24 @@
+package net.gspatace.json.schema.podo.generator.rest.models;
+
+import lombok.Data;
+
+/**
+ * DTO for specific generator options
+ *
+ * @author George Spătăcean
+ */
+@Data
+public class CustomOption {
+    /**
+     * name of a property as registered in the
+     * {@link net.gspatace.json.schema.podo.generator.core.annotations.CustomProperties}
+     * e.g. "-v","--version"
+     */
+    private String name;
+
+    /**
+     * Value to be passed to the option
+     * e.g. "1.0-RELEASE"
+     */
+    private String value;
+}

--- a/modules/rest-api/src/main/resources/application.yaml
+++ b/modules/rest-api/src/main/resources/application.yaml
@@ -1,0 +1,3 @@
+logging:
+  level:
+    net.gspatace.json.schema.podo.generator: trace

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
   <modules>
     <module>modules/core</module>
     <module>modules/cli-wrapper</module>
+    <module>modules/rest-api</module>
   </modules>
 
   <build>


### PR DESCRIPTION
- Replace org.reflections:reflections with io.github.classgraph:classgraph due to packaging issues with Spring Boot Maven Plugin
- Add REST API wrappers over core generatior logic -List generators -List specific generator options -Generate code using a generator
